### PR TITLE
Investigate thirdweb module loading error

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -47,9 +47,37 @@ const nextConfig = {
       },
     });
 
+    // Ensure ESM modules are handled correctly
+    config.experiments = {
+      ...config.experiments,
+      asyncWebAssembly: true,
+      layers: true,
+    };
+    
+    // Handle module resolution for thirdweb
+    if (!isServer) {
+      // Ensure thirdweb modules are properly resolved
+      config.resolve = {
+        ...config.resolve,
+        extensionAlias: {
+          '.js': ['.js', '.ts', '.tsx', '.jsx'],
+          '.mjs': ['.mjs', '.mts'],
+          '.cjs': ['.cjs', '.cts']
+        }
+      };
+    }
+
     return config;
   },
-  transpilePackages: ['thirdweb', '@thirdweb-dev/ai-sdk-provider'],
+  transpilePackages: [
+    'thirdweb', 
+    '@thirdweb-dev/ai-sdk-provider',
+    'thirdweb/react',
+    'thirdweb/extensions',
+    'thirdweb/wallets',
+    'thirdweb/utils',
+    'thirdweb/storage'
+  ],
 }
 
 mergeConfig(nextConfig, userConfig)


### PR DESCRIPTION
Update Next.js configuration to correctly transpile and resolve `thirdweb` ESM modules, fixing "Failed to load 'thirdweb'" MIME type errors.

The previous configuration did not properly handle `thirdweb`'s ES module structure, leading to MIME type errors when modules were loaded as `blob:` URLs. This PR expands `transpilePackages` and adds `experiments` and `extensionAlias` to ensure `thirdweb` modules are correctly processed by Next.js.

---
<a href="https://cursor.com/background-agent?bcId=bc-0ef69f2b-a8b6-40f4-abd8-40d9f28b9f99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0ef69f2b-a8b6-40f4-abd8-40d9f28b9f99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

